### PR TITLE
feat: enable systemd by default

### DIFF
--- a/etc/wsl.conf
+++ b/etc/wsl.conf
@@ -1,0 +1,2 @@
+[boot]
+systemd=true


### PR DESCRIPTION
This PR will enable systemd by default to WSL by adding `/etc/wsl.conf` with `systemd=true` to the `[boot]` section.

The reasoning for adding systemd by default is because I encountered some small issues when running the Fedora WSL like not being able to ping, not being able to start system services, not being able to use Docker, etc until I enabled systemd.

Ubuntu's WSL images all have the systemd enabled by default (in their rootfs) so it is probably expected behavior for most devs using WSL.